### PR TITLE
Allow Users to specify full ingress spec

### DIFF
--- a/api/v1alpha1/oauthproxy_types.go
+++ b/api/v1alpha1/oauthproxy_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -32,6 +33,9 @@ type OAuthProxySpec struct {
 	Host string `json:"host,omitempty"`
 	// RedirectURL for the OIDC flow.
 	RedirectURL string `json:"redirectURL"`
+	// Ingress allows specifying the ingress. Overwrites host.
+	// +optional
+	Ingress *networkingv1.IngressSpec `json:"ingress,omitempty"`
 }
 
 // OAuthProxyStatus defines the observed state of OAuthProxy

--- a/config/crd/bases/security.nine.ch_oauthproxies.yaml
+++ b/config/crd/bases/security.nine.ch_oauthproxies.yaml
@@ -40,6 +40,269 @@ spec:
                 description: Host is the hostname where the oauthProxy should be available
                   at. Only optional if an Ingress is specified.
                 type: string
+              ingress:
+                description: Ingress allows specifying the ingress. Overwrites host.
+                properties:
+                  defaultBackend:
+                    description: DefaultBackend is the backend that should handle
+                      requests that don't match any rule. If Rules are not specified,
+                      DefaultBackend must be specified. If DefaultBackend is not set,
+                      the handling of requests that do not match any of the rules
+                      will be up to the Ingress controller.
+                    properties:
+                      resource:
+                        description: Resource is an ObjectRef to another Kubernetes
+                          resource in the namespace of the Ingress object. If resource
+                          is specified, a service.Name and service.Port must not be
+                          specified. This is a mutually exclusive setting with "Service".
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      service:
+                        description: Service references a Service as a Backend. This
+                          is a mutually exclusive setting with "Resource".
+                        properties:
+                          name:
+                            description: Name is the referenced service. The service
+                              must exist in the same namespace as the Ingress object.
+                            type: string
+                          port:
+                            description: Port of the referenced service. A port name
+                              or port number is required for a IngressServiceBackend.
+                            properties:
+                              name:
+                                description: Name is the name of the port on the Service.
+                                  This is a mutually exclusive setting with "Number".
+                                type: string
+                              number:
+                                description: Number is the numerical port number (e.g.
+                                  80) on the Service. This is a mutually exclusive
+                                  setting with "Name".
+                                format: int32
+                                type: integer
+                            type: object
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  ingressClassName:
+                    description: IngressClassName is the name of the IngressClass
+                      cluster resource. The associated IngressClass defines which
+                      controller will implement the resource. This replaces the deprecated
+                      `kubernetes.io/ingress.class` annotation. For backwards compatibility,
+                      when that annotation is set, it must be given precedence over
+                      this field. The controller may emit a warning if the field and
+                      annotation have different values. Implementations of this API
+                      should ignore Ingresses without a class specified. An IngressClass
+                      resource may be marked as default, which can be used to set
+                      a default value for this field. For more information, refer
+                      to the IngressClass documentation.
+                    type: string
+                  rules:
+                    description: A list of host rules used to configure the Ingress.
+                      If unspecified, or no rule matches, all traffic is sent to the
+                      default backend.
+                    items:
+                      description: IngressRule represents the rules mapping the paths
+                        under a specified host to the related backend services. Incoming
+                        requests are first evaluated for a host match, then routed
+                        to the backend associated with the matching IngressRuleValue.
+                      properties:
+                        host:
+                          description: "Host is the fully qualified domain name of
+                            a network host, as defined by RFC 3986. Note the following
+                            deviations from the \"host\" part of the URI as defined
+                            in RFC 3986: 1. IPs are not allowed. Currently an IngressRuleValue
+                            can only apply to    the IP in the Spec of the parent
+                            Ingress. 2. The `:` delimiter is not respected because
+                            ports are not allowed. \t  Currently the port of an Ingress
+                            is implicitly :80 for http and \t  :443 for https. Both
+                            these may change in the future. Incoming requests are
+                            matched against the host before the IngressRuleValue.
+                            If the host is unspecified, the Ingress routes all traffic
+                            based on the specified IngressRuleValue. \n Host can be
+                            \"precise\" which is a domain name without the terminating
+                            dot of a network host (e.g. \"foo.bar.com\") or \"wildcard\",
+                            which is a domain name prefixed with a single wildcard
+                            label (e.g. \"*.foo.com\"). The wildcard character '*'
+                            must appear by itself as the first DNS label and matches
+                            only a single label. You cannot have a wildcard label
+                            by itself (e.g. Host == \"*\"). Requests will be matched
+                            against the Host field in the following way: 1. If Host
+                            is precise, the request matches this rule if the http
+                            host header is equal to Host. 2. If Host is a wildcard,
+                            then the request matches this rule if the http host header
+                            is to equal to the suffix (removing the first label) of
+                            the wildcard rule."
+                          type: string
+                        http:
+                          description: 'HTTPIngressRuleValue is a list of http selectors
+                            pointing to backends. In the example: http://<host>/<path>?<searchpart>
+                            -> backend where where parts of the url correspond to
+                            RFC 3986, this resource will be used to match against
+                            everything after the last ''/'' and before the first ''?''
+                            or ''#''.'
+                          properties:
+                            paths:
+                              description: A collection of paths that map requests
+                                to backends.
+                              items:
+                                description: HTTPIngressPath associates a path with
+                                  a backend. Incoming urls matching the path are forwarded
+                                  to the backend.
+                                properties:
+                                  backend:
+                                    description: Backend defines the referenced service
+                                      endpoint to which the traffic will be forwarded
+                                      to.
+                                    properties:
+                                      resource:
+                                        description: Resource is an ObjectRef to another
+                                          Kubernetes resource in the namespace of
+                                          the Ingress object. If resource is specified,
+                                          a service.Name and service.Port must not
+                                          be specified. This is a mutually exclusive
+                                          setting with "Service".
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      service:
+                                        description: Service references a Service
+                                          as a Backend. This is a mutually exclusive
+                                          setting with "Resource".
+                                        properties:
+                                          name:
+                                            description: Name is the referenced service.
+                                              The service must exist in the same namespace
+                                              as the Ingress object.
+                                            type: string
+                                          port:
+                                            description: Port of the referenced service.
+                                              A port name or port number is required
+                                              for a IngressServiceBackend.
+                                            properties:
+                                              name:
+                                                description: Name is the name of the
+                                                  port on the Service. This is a mutually
+                                                  exclusive setting with "Number".
+                                                type: string
+                                              number:
+                                                description: Number is the numerical
+                                                  port number (e.g. 80) on the Service.
+                                                  This is a mutually exclusive setting
+                                                  with "Name".
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                    type: object
+                                  path:
+                                    description: Path is matched against the path
+                                      of an incoming request. Currently it can contain
+                                      characters disallowed from the conventional
+                                      "path" part of a URL as defined by RFC 3986.
+                                      Paths must begin with a '/' and must be present
+                                      when using PathType with value "Exact" or "Prefix".
+                                    type: string
+                                  pathType:
+                                    description: 'PathType determines the interpretation
+                                      of the Path matching. PathType can be one of
+                                      the following values: * Exact: Matches the URL
+                                      path exactly. * Prefix: Matches based on a URL
+                                      path prefix split by ''/''. Matching is   done
+                                      on a path element by element basis. A path element
+                                      refers is the   list of labels in the path split
+                                      by the ''/'' separator. A request is a   match
+                                      for path p if every p is an element-wise prefix
+                                      of p of the   request path. Note that if the
+                                      last element of the path is a substring   of
+                                      the last element in request path, it is not
+                                      a match (e.g. /foo/bar   matches /foo/bar/baz,
+                                      but does not match /foo/barbaz). * ImplementationSpecific:
+                                      Interpretation of the Path matching is up to   the
+                                      IngressClass. Implementations can treat this
+                                      as a separate PathType   or treat it identically
+                                      to Prefix or Exact path types. Implementations
+                                      are required to support all path types.'
+                                    type: string
+                                required:
+                                - backend
+                                - pathType
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - paths
+                          type: object
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  tls:
+                    description: TLS configuration. Currently the Ingress only supports
+                      a single TLS port, 443. If multiple members of this list specify
+                      different hosts, they will be multiplexed on the same port according
+                      to the hostname specified through the SNI TLS extension, if
+                      the ingress controller fulfilling the ingress supports SNI.
+                    items:
+                      description: IngressTLS describes the transport layer security
+                        associated with an Ingress.
+                      properties:
+                        hosts:
+                          description: Hosts are a list of hosts included in the TLS
+                            certificate. The values in this list must match the name/s
+                            used in the tlsSecret. Defaults to the wildcard host setting
+                            for the loadbalancer controller fulfilling this Ingress,
+                            if left unspecified.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        secretName:
+                          description: SecretName is the name of the secret used to
+                            terminate TLS traffic on port 443. Field is left optional
+                            to allow TLS routing based on SNI hostname alone. If the
+                            SNI host in a listener conflicts with the "Host" header
+                            field used by an IngressRule, the SNI host is used for
+                            termination and value of the Host header is used for routing.
+                          type: string
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
               redirectURL:
                 description: RedirectURL for the OIDC flow.
                 type: string

--- a/controllers/oidc.go
+++ b/controllers/oidc.go
@@ -1,7 +1,7 @@
 package controllers
 
 type KeycloakClient struct {
-	// TODO: implement
+	// TODO: implement.
 }
 
 func (k *KeycloakClient) GetOIDCConfig(clientName string, redirectURL string) (*OidcConfig, error) {

--- a/main.go
+++ b/main.go
@@ -20,8 +20,6 @@ import (
 	"flag"
 	"os"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
This commit adds a field to the OAuthProxy CRD so that users can specify
the ingress spec that will be used in front of oauth proxy.